### PR TITLE
add timezone adjustment for event timestamp

### DIFF
--- a/Analogy.LogViewer.Serilog/ClefParser.cs
+++ b/Analogy.LogViewer.Serilog/ClefParser.cs
@@ -12,6 +12,8 @@ namespace Analogy.LogViewer.Serilog
 {
     public class ClefParser
     {
+        public TimeZoneInfo TimeStampTimeZone { get; set; } = null;
+
         public async Task<IEnumerable<AnalogyLogMessage>> Process(string fileName, CancellationToken token, ILogMessageCreatedHandler messagesHandler)
         {
             var messages = await Task<IEnumerable<AnalogyLogMessage>>.Factory.StartNew(() =>
@@ -31,6 +33,10 @@ namespace Analogy.LogViewer.Serilog
                             {
                                 analogy.Write(evt);
                                 AnalogyLogMessage m = CommonParser.ParseLogEventProperties(evt);
+                                if (TimeStampTimeZone != null)
+                                {
+                                    m.Date = TimeZoneInfo.ConvertTimeFromUtc(m.Date, TimeStampTimeZone);
+                                }
                                 parsedMessages.Add(m);
                             }
 

--- a/Analogy.LogViewer.Serilog/CommonParser.cs
+++ b/Analogy.LogViewer.Serilog/CommonParser.cs
@@ -6,7 +6,6 @@ namespace Analogy.LogViewer.Serilog
 {
     public static class CommonParser
     {
-
         public static AnalogyLogMessage ParseLogEventProperties(LogEvent evt)
         {
             AnalogyLogMessage m = new AnalogyLogMessage();

--- a/Analogy.LogViewer.Serilog/IAnalogy/OfflineDataProvider.cs
+++ b/Analogy.LogViewer.Serilog/IAnalogy/OfflineDataProvider.cs
@@ -36,6 +36,7 @@ namespace Analogy.LogViewer.Serilog.IAnalogy
 
         public (Color backgroundColor, Color foregroundColor) GetColorForMessage(IAnalogyLogMessage logMessage)
             => (Color.Empty, Color.Empty);
+
         public OfflineDataProvider()
         {
             ClefParser = new ClefParser();
@@ -44,10 +45,32 @@ namespace Analogy.LogViewer.Serilog.IAnalogy
                 LogManager.Instance);
 
         }
+
+        private void TrySetSerilogTimeStampTimeZoneAdjustment()
+        {
+            if (UserSettingsManager.UserSettings.Settings.UserTimeZone != string.Empty)
+            {
+                try
+                {
+                    var userTimeZone = TimeZoneInfo.FindSystemTimeZoneById(
+                        UserSettingsManager.UserSettings.Settings.UserTimeZone);
+                    ClefParser.TimeStampTimeZone = userTimeZone;
+                    JsonParser.TimeStampTimeZone = userTimeZone;
+                    RegexParser.TimeStampTimeZone = userTimeZone;
+                }
+                catch (Exception ex)
+                {
+                    // ignore
+                    // TODO: log
+                }
+            }
+        }
+
         public async Task<IEnumerable<AnalogyLogMessage>> Process(string fileName, CancellationToken token, ILogMessageCreatedHandler messagesHandler)
         {
             if (CanOpenFile(fileName))
             {
+                TrySetSerilogTimeStampTimeZoneAdjustment();
                 switch (UserSettingsManager.UserSettings.Settings.Format)
                 {
                     case SerilogFileFormat.CLEF:

--- a/Analogy.LogViewer.Serilog/JsonParser.cs
+++ b/Analogy.LogViewer.Serilog/JsonParser.cs
@@ -18,6 +18,8 @@ namespace Analogy.LogViewer.Serilog
     public class JsonParser
     {
         public static ITextFormatter textFormatter;
+        public TimeZoneInfo TimeStampTimeZone { get; set; } = null;
+
         public async Task<IEnumerable<AnalogyLogMessage>> Process(string fileName, CancellationToken token, ILogMessageCreatedHandler messagesHandler)
         {
             var messages = await Task<IEnumerable<AnalogyLogMessage>>.Factory.StartNew(() =>
@@ -50,6 +52,14 @@ namespace Analogy.LogViewer.Serilog
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    if (TimeStampTimeZone != null)
+                    {
+                        foreach (var m in parsedMessages)
+                        {
+                            m.Date = TimeZoneInfo.ConvertTimeFromUtc(m.Date, TimeStampTimeZone);
                         }
                     }
 

--- a/Analogy.LogViewer.Serilog/Regex/RegexParser.cs
+++ b/Analogy.LogViewer.Serilog/Regex/RegexParser.cs
@@ -18,6 +18,7 @@ namespace Analogy.LogViewer.Serilog.Regex
         private List<RegexPattern> _logPatterns;
         private readonly bool updateUIAfterEachParsedLine;
         private IAnalogyLogger Logger { get; }
+        public static TimeZoneInfo TimeStampTimeZone { get; set; } = null;
 
         private IEnumerable<RegexPattern> LogPatterns
         {
@@ -82,7 +83,7 @@ namespace Analogy.LogViewer.Serilog.Regex
                                     DateTime.TryParseExact(value, regex.DateTimeFormat, CultureInfo.InvariantCulture,
                                         DateTimeStyles.None, out var date))
                                 {
-                                    m.Date = date;
+                                    m.Date = TimeStampTimeZone == null ? date : TimeZoneInfo.ConvertTimeToUtc(date);
                                 }
 
                                 continue;

--- a/Analogy.LogViewer.Serilog/SerilogSettings.cs
+++ b/Analogy.LogViewer.Serilog/SerilogSettings.cs
@@ -17,6 +17,7 @@ namespace Analogy.LogViewer.Serilog
         public List<RegexPattern> RegexPatterns { get; set; }
         public string Directory { get; set; }
         public SerilogFileFormat Format { get; set; }
+        public string UserTimeZone { get; set; }
 
         public SerilogSettings()
         {
@@ -26,11 +27,7 @@ namespace Analogy.LogViewer.Serilog
             SupportFormats = new List<string> { "*.Clef", "*.log" };
             RegexPatterns = new List<RegexPattern>();
             RegexPatterns.Add(new RegexPattern(@"\$(?<Date>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})+\|+(?<Thread>\d+)+\|(?<Level>\w+)+\|+(?<Source>.*)\|(?<Text>.*)", "yyyy-MM-dd HH:mm:ss,fff", ""));
-
+            UserTimeZone = string.Empty;
         }
-
-
-
-
     }
 }

--- a/Analogy.LogViewer.Serilog/SerilogUCSettings.Designer.cs
+++ b/Analogy.LogViewer.Serilog/SerilogUCSettings.Designer.cs
@@ -60,6 +60,8 @@
             this.txtbOpenFileFilters = new System.Windows.Forms.TextBox();
             this.lblOpenfilesFilters = new System.Windows.Forms.Label();
             this.btnTestFilter = new System.Windows.Forms.Button();
+            this.label4 = new System.Windows.Forms.Label();
+            this.timeZoneComboBox = new System.Windows.Forms.ComboBox();
             this.tcSetttings.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.gbresult.SuspendLayout();
@@ -68,7 +70,7 @@
             // btnSave
             // 
             this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSave.Location = new System.Drawing.Point(589, 590);
+            this.btnSave.Location = new System.Drawing.Point(589, 657);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(133, 47);
             this.btnSave.TabIndex = 1;
@@ -79,7 +81,7 @@
             // btnExportSettings
             // 
             this.btnExportSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnExportSettings.Location = new System.Drawing.Point(450, 590);
+            this.btnExportSettings.Location = new System.Drawing.Point(450, 657);
             this.btnExportSettings.Name = "btnExportSettings";
             this.btnExportSettings.Size = new System.Drawing.Size(133, 47);
             this.btnExportSettings.TabIndex = 2;
@@ -92,7 +94,7 @@
             this.lblLayout.AutoSize = true;
             this.lblLayout.Location = new System.Drawing.Point(3, 6);
             this.lblLayout.Name = "lblLayout";
-            this.lblLayout.Size = new System.Drawing.Size(60, 18);
+            this.lblLayout.Size = new System.Drawing.Size(49, 14);
             this.lblLayout.TabIndex = 3;
             this.lblLayout.Text = "Format:";
             // 
@@ -100,25 +102,25 @@
             // 
             this.txtbSupportedFiles.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtbSupportedFiles.Location = new System.Drawing.Point(197, 131);
+            this.txtbSupportedFiles.Location = new System.Drawing.Point(198, 171);
             this.txtbSupportedFiles.Name = "txtbSupportedFiles";
-            this.txtbSupportedFiles.Size = new System.Drawing.Size(524, 26);
+            this.txtbSupportedFiles.Size = new System.Drawing.Size(524, 22);
             this.txtbSupportedFiles.TabIndex = 9;
             this.txtbSupportedFiles.Text = "*.Clef";
             // 
             // label2
             // 
             this.label2.AutoEllipsis = true;
-            this.label2.Location = new System.Drawing.Point(3, 132);
+            this.label2.Location = new System.Drawing.Point(4, 172);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(188, 50);
+            this.label2.Size = new System.Drawing.Size(188, 38);
             this.label2.TabIndex = 8;
             this.label2.Text = "Supported Log Formats (use ; as separator):";
             // 
             // btnImport
             // 
             this.btnImport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnImport.Location = new System.Drawing.Point(307, 590);
+            this.btnImport.Location = new System.Drawing.Point(307, 657);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(137, 47);
             this.btnImport.TabIndex = 10;
@@ -130,24 +132,24 @@
             // 
             this.txtbDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtbDirectory.Location = new System.Drawing.Point(197, 76);
+            this.txtbDirectory.Location = new System.Drawing.Point(198, 116);
             this.txtbDirectory.Name = "txtbDirectory";
-            this.txtbDirectory.Size = new System.Drawing.Size(463, 26);
+            this.txtbDirectory.Size = new System.Drawing.Size(463, 22);
             this.txtbDirectory.TabIndex = 12;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 78);
+            this.label3.Location = new System.Drawing.Point(3, 116);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(152, 18);
+            this.label3.Size = new System.Drawing.Size(129, 14);
             this.label3.TabIndex = 11;
             this.label3.Text = "Default Logs Location:";
             // 
             // btnOpenFolder
             // 
             this.btnOpenFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOpenFolder.Location = new System.Drawing.Point(674, 76);
+            this.btnOpenFolder.Location = new System.Drawing.Point(675, 116);
             this.btnOpenFolder.Name = "btnOpenFolder";
             this.btnOpenFolder.Size = new System.Drawing.Size(47, 22);
             this.btnOpenFolder.TabIndex = 13;
@@ -161,7 +163,7 @@
             this.rbtnCLEF.Checked = true;
             this.rbtnCLEF.Location = new System.Drawing.Point(87, 3);
             this.rbtnCLEF.Name = "rbtnCLEF";
-            this.rbtnCLEF.Size = new System.Drawing.Size(231, 22);
+            this.rbtnCLEF.Size = new System.Drawing.Size(194, 18);
             this.rbtnCLEF.TabIndex = 14;
             this.rbtnCLEF.TabStop = true;
             this.rbtnCLEF.Text = "Compact Log Event File (CLEF)";
@@ -172,7 +174,7 @@
             this.rbJson.AutoSize = true;
             this.rbJson.Location = new System.Drawing.Point(87, 51);
             this.rbJson.Name = "rbJson";
-            this.rbJson.Size = new System.Drawing.Size(153, 22);
+            this.rbJson.Size = new System.Drawing.Size(130, 18);
             this.rbJson.TabIndex = 15;
             this.rbJson.Text = "Json Log Event File";
             this.rbJson.UseVisualStyleBackColor = true;
@@ -182,7 +184,7 @@
             this.rbRegexFile.AutoSize = true;
             this.rbRegexFile.Location = new System.Drawing.Point(87, 27);
             this.rbRegexFile.Name = "rbRegexFile";
-            this.rbRegexFile.Size = new System.Drawing.Size(289, 22);
+            this.rbRegexFile.Size = new System.Drawing.Size(240, 18);
             this.rbRegexFile.TabIndex = 16;
             this.rbRegexFile.Text = "Text file - use regular expression parser";
             this.rbRegexFile.UseVisualStyleBackColor = true;
@@ -193,10 +195,10 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tcSetttings.Controls.Add(this.tabPage2);
-            this.tcSetttings.Location = new System.Drawing.Point(6, 172);
+            this.tcSetttings.Location = new System.Drawing.Point(6, 213);
             this.tcSetttings.Name = "tcSetttings";
             this.tcSetttings.SelectedIndex = 0;
-            this.tcSetttings.Size = new System.Drawing.Size(715, 412);
+            this.tcSetttings.Size = new System.Drawing.Size(715, 438);
             this.tcSetttings.TabIndex = 45;
             // 
             // tabPage2
@@ -214,10 +216,10 @@
             this.tabPage2.Controls.Add(this.lblDateTimeFormat);
             this.tabPage2.Controls.Add(this.lblRegex);
             this.tabPage2.Controls.Add(this.btnTest);
-            this.tabPage2.Location = new System.Drawing.Point(4, 27);
+            this.tabPage2.Location = new System.Drawing.Point(4, 23);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(707, 381);
+            this.tabPage2.Size = new System.Drawing.Size(707, 411);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Text file - Regular Expression Parser";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -227,7 +229,7 @@
             this.txtbGuidFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.txtbGuidFormat.Location = new System.Drawing.Point(277, 58);
             this.txtbGuidFormat.Name = "txtbGuidFormat";
-            this.txtbGuidFormat.Size = new System.Drawing.Size(360, 26);
+            this.txtbGuidFormat.Size = new System.Drawing.Size(360, 22);
             this.txtbGuidFormat.TabIndex = 58;
             // 
             // label1
@@ -270,7 +272,7 @@
             this.lstbRegularExpressions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lstbRegularExpressions.FormattingEnabled = true;
-            this.lstbRegularExpressions.ItemHeight = 18;
+            this.lstbRegularExpressions.ItemHeight = 14;
             this.lstbRegularExpressions.Location = new System.Drawing.Point(9, 113);
             this.lstbRegularExpressions.Name = "lstbRegularExpressions";
             this.lstbRegularExpressions.Size = new System.Drawing.Size(590, 130);
@@ -285,7 +287,7 @@
             this.gbresult.Controls.Add(this.lblResult);
             this.gbresult.Location = new System.Drawing.Point(9, 294);
             this.gbresult.Name = "gbresult";
-            this.gbresult.Size = new System.Drawing.Size(590, 75);
+            this.gbresult.Size = new System.Drawing.Size(590, 101);
             this.gbresult.TabIndex = 52;
             this.gbresult.TabStop = false;
             this.gbresult.Text = "Result";
@@ -293,15 +295,15 @@
             // lblResultMessage
             // 
             this.lblResultMessage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblResultMessage.Location = new System.Drawing.Point(3, 41);
+            this.lblResultMessage.Location = new System.Drawing.Point(3, 37);
             this.lblResultMessage.Name = "lblResultMessage";
-            this.lblResultMessage.Size = new System.Drawing.Size(584, 31);
+            this.lblResultMessage.Size = new System.Drawing.Size(584, 61);
             this.lblResultMessage.TabIndex = 31;
             // 
             // lblResult
             // 
             this.lblResult.Dock = System.Windows.Forms.DockStyle.Top;
-            this.lblResult.Location = new System.Drawing.Point(3, 22);
+            this.lblResult.Location = new System.Drawing.Point(3, 18);
             this.lblResult.Name = "lblResult";
             this.lblResult.Size = new System.Drawing.Size(584, 19);
             this.lblResult.TabIndex = 30;
@@ -312,7 +314,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtbTest.Location = new System.Drawing.Point(119, 266);
             this.txtbTest.Name = "txtbTest";
-            this.txtbTest.Size = new System.Drawing.Size(480, 26);
+            this.txtbTest.Size = new System.Drawing.Size(480, 22);
             this.txtbTest.TabIndex = 51;
             // 
             // lblLogTest
@@ -321,7 +323,7 @@
             this.lblLogTest.AutoSize = true;
             this.lblLogTest.Location = new System.Drawing.Point(6, 269);
             this.lblLogTest.Name = "lblLogTest";
-            this.lblLogTest.Size = new System.Drawing.Size(109, 18);
+            this.lblLogTest.Size = new System.Drawing.Size(95, 14);
             this.lblLogTest.TabIndex = 50;
             this.lblLogTest.Text = "Log line to test:";
             // 
@@ -331,7 +333,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtbDateTimeFormat.Location = new System.Drawing.Point(188, 29);
             this.txtbDateTimeFormat.Name = "txtbDateTimeFormat";
-            this.txtbDateTimeFormat.Size = new System.Drawing.Size(513, 26);
+            this.txtbDateTimeFormat.Size = new System.Drawing.Size(513, 22);
             this.txtbDateTimeFormat.TabIndex = 48;
             this.txtbDateTimeFormat.Text = "yyyy-MM-dd HH:mm:ss,fff";
             // 
@@ -341,7 +343,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtbRegEx.Location = new System.Drawing.Point(188, 6);
             this.txtbRegEx.Name = "txtbRegEx";
-            this.txtbRegEx.Size = new System.Drawing.Size(513, 26);
+            this.txtbRegEx.Size = new System.Drawing.Size(513, 22);
             this.txtbRegEx.TabIndex = 49;
             // 
             // lblDateTimeFormat
@@ -350,7 +352,7 @@
             this.lblDateTimeFormat.AutoSize = true;
             this.lblDateTimeFormat.Location = new System.Drawing.Point(6, 37);
             this.lblDateTimeFormat.Name = "lblDateTimeFormat";
-            this.lblDateTimeFormat.Size = new System.Drawing.Size(149, 18);
+            this.lblDateTimeFormat.Size = new System.Drawing.Size(124, 14);
             this.lblDateTimeFormat.TabIndex = 46;
             this.lblDateTimeFormat.Text = "DateTime log format:";
             // 
@@ -360,7 +362,7 @@
             this.lblRegex.AutoSize = true;
             this.lblRegex.Location = new System.Drawing.Point(6, 10);
             this.lblRegex.Name = "lblRegex";
-            this.lblRegex.Size = new System.Drawing.Size(163, 18);
+            this.lblRegex.Size = new System.Drawing.Size(136, 14);
             this.lblRegex.TabIndex = 47;
             this.lblRegex.Text = "Log Regular Expression:";
             // 
@@ -379,15 +381,15 @@
             // 
             this.txtbOpenFileFilters.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtbOpenFileFilters.Location = new System.Drawing.Point(197, 103);
+            this.txtbOpenFileFilters.Location = new System.Drawing.Point(198, 143);
             this.txtbOpenFileFilters.Name = "txtbOpenFileFilters";
-            this.txtbOpenFileFilters.Size = new System.Drawing.Size(463, 26);
+            this.txtbOpenFileFilters.Size = new System.Drawing.Size(463, 22);
             this.txtbOpenFileFilters.TabIndex = 47;
             // 
             // lblOpenfilesFilters
             // 
             this.lblOpenfilesFilters.AutoEllipsis = true;
-            this.lblOpenfilesFilters.Location = new System.Drawing.Point(7, 103);
+            this.lblOpenfilesFilters.Location = new System.Drawing.Point(3, 143);
             this.lblOpenfilesFilters.Name = "lblOpenfilesFilters";
             this.lblOpenfilesFilters.Size = new System.Drawing.Size(184, 22);
             this.lblOpenfilesFilters.TabIndex = 46;
@@ -396,7 +398,7 @@
             // btnTestFilter
             // 
             this.btnTestFilter.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnTestFilter.Location = new System.Drawing.Point(674, 103);
+            this.btnTestFilter.Location = new System.Drawing.Point(675, 143);
             this.btnTestFilter.Name = "btnTestFilter";
             this.btnTestFilter.Size = new System.Drawing.Size(47, 25);
             this.btnTestFilter.TabIndex = 48;
@@ -404,10 +406,29 @@
             this.btnTestFilter.UseVisualStyleBackColor = true;
             this.btnTestFilter.Click += new System.EventHandler(this.btnTestFilter_Click);
             // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(4, 87);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(91, 14);
+            this.label4.TabIndex = 49;
+            this.label4.Text = "Logs TimeZone";
+            // 
+            // timeZoneComboBox
+            // 
+            this.timeZoneComboBox.FormattingEnabled = true;
+            this.timeZoneComboBox.Location = new System.Drawing.Point(198, 87);
+            this.timeZoneComboBox.Name = "timeZoneComboBox";
+            this.timeZoneComboBox.Size = new System.Drawing.Size(463, 22);
+            this.timeZoneComboBox.TabIndex = 50;
+            // 
             // SerilogUCSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 18F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.timeZoneComboBox);
+            this.Controls.Add(this.label4);
             this.Controls.Add(this.btnTestFilter);
             this.Controls.Add(this.txtbOpenFileFilters);
             this.Controls.Add(this.lblOpenfilesFilters);
@@ -426,7 +447,7 @@
             this.Controls.Add(this.btnSave);
             this.Font = new System.Drawing.Font("Tahoma", 9F);
             this.Name = "SerilogUCSettings";
-            this.Size = new System.Drawing.Size(725, 640);
+            this.Size = new System.Drawing.Size(725, 707);
             this.Load += new System.EventHandler(this.NLogSettings_Load);
             this.tcSetttings.ResumeLayout(false);
             this.tabPage2.ResumeLayout(false);
@@ -470,5 +491,7 @@
         private System.Windows.Forms.TextBox txtbOpenFileFilters;
         private System.Windows.Forms.Label lblOpenfilesFilters;
         private System.Windows.Forms.Button btnTestFilter;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.ComboBox timeZoneComboBox;
     }
 }

--- a/Analogy.LogViewer.Serilog/SerilogUCSettings.cs
+++ b/Analogy.LogViewer.Serilog/SerilogUCSettings.cs
@@ -14,14 +14,23 @@ namespace Analogy.LogViewer.Serilog
     public partial class SerilogUCSettings : UserControl
     {
         private SerilogSettings Settings => UserSettingsManager.UserSettings.Settings;
+        private IReadOnlyCollection<TimeZoneInfo> _systemTimeZones;
+        
         public SerilogUCSettings()
         {
             InitializeComponent();
+            LoadSystemTimeZones();
         }
 
         private void btnSave_Click(object sender, EventArgs e)
         {
             SaveSettings();
+        }
+
+        private void LoadSystemTimeZones()
+        {
+            _systemTimeZones =  TimeZoneInfo.GetSystemTimeZones();
+            timeZoneComboBox.DataSource = _systemTimeZones;
         }
         public void SaveSettings()
         {
@@ -38,6 +47,7 @@ namespace Analogy.LogViewer.Serilog
             Settings.Format = rbtnCLEF.Checked
                 ? SerilogFileFormat.CLEF
                 : (rbRegexFile.Checked ? SerilogFileFormat.REGEX : SerilogFileFormat.JSON);
+            Settings.UserTimeZone = ((TimeZoneInfo)timeZoneComboBox.SelectedItem).Id;
             UserSettingsManager.UserSettings.Save();
         }
 
@@ -101,6 +111,14 @@ namespace Analogy.LogViewer.Serilog
             rbtnCLEF.Checked = logSettings.Format == SerilogFileFormat.CLEF;
             rbRegexFile.Checked = logSettings.Format == SerilogFileFormat.REGEX;
             rbJson.Checked = logSettings.Format == SerilogFileFormat.JSON;
+            try
+            {
+                timeZoneComboBox.SelectedItem = TimeZoneInfo.FindSystemTimeZoneById(logSettings.UserTimeZone);
+            }
+            catch(Exception ex)
+            {
+                timeZoneComboBox.SelectedItem = null;
+            }
         }
 
         private void btnOpenFolder_Click(object sender, EventArgs e)


### PR DESCRIPTION
Timestamps in `CompactJsonFormatter` are in UTC time standard. This pr enables to choose a custom timezone to adjust event timestamps.
refs:

- [https://github.com/serilog/serilog-formatting-compact/blob/dev/src/Serilog.Formatting.Compact/Formatting/Compact/CompactJsonFormatter.cs#L65](https://github.com/serilog/serilog-formatting-compact/blob/dev/src/Serilog.Formatting.Compact/Formatting/Compact/CompactJsonFormatter.cs#L65)